### PR TITLE
[FIX] init default union transform before assign meta encoder transform

### DIFF
--- a/fastclasses_json/core.py
+++ b/fastclasses_json/core.py
@@ -208,6 +208,9 @@ def _to_dict_source(cls):
 
         access = f'self.{name}'
 
+        if typing.get_origin(field_type) == typing.Union:
+            field_type = expr_builder_to(typing.get_args(field_type)[0])
+        
         transform = expr_builder_to(field_type)
 
         # custom encoder and decoder routines
@@ -226,10 +229,6 @@ def _to_dict_source(cls):
                 )
 
         if transform('x') != 'x':
-            # since we have an is not none check, elide the first level
-            # of optional
-            if typing.get_origin(field_type) == typing.Union:
-                transform = expr_builder_to(typing.get_args(field_type)[0])
             lines.append(f'    value = {access}')
             lines.append(f'    if value is not None:')  # noqa: F541
             lines.append(f'        value = ' + transform('value'))  # noqa: E501,F541


### PR DESCRIPTION
I'm using your fastclasses-json to do serialization and deserialization, but I found my encoder for an Union type field not working, so I dig the source code and found the default transform for Union will override the provided encoder transform, so I try to fix like that, if it will causing another problem? If my edit is functionable, could you release a newer version?